### PR TITLE
[00049] Add GitHub Actions CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm run lint


### PR DESCRIPTION
Added `.github/workflows/ci.yml` to the `try-tone` repo. The workflow runs `pnpm run build` and `pnpm run lint` on every pull request and every push to `main`, using `pnpm` with Node 22.

## API Changes

None.

## Files Modified

- `.github/workflows/ci.yml` — new GitHub Actions CI workflow (triggers on PR and push to main)

---

Commits:
- b701fe6 [00049] Add GitHub Actions CI workflow