### PR TITLE
[00050] Update Renovate Grouping and Automerge Config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "schedule": ["before 9am on Monday"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    }
   ]
 }


### PR DESCRIPTION
# Summary

## Changes

Updated `renovate.json` to add dependency grouping, automerge, and a weekly schedule. Minor and patch updates are now grouped into a single PR (`all non-major dependencies`) that automerges via squash once CI passes. Major upgrades remain as separate individual PRs for manual review. Updates run before 9am on Monday.

## API Changes

None.

## Files Modified

- `renovate.json` — Added `schedule`, `packageRules` with grouping and automerge for minor/patch updates

---
- b603b3e [00050] Update Renovate config with grouping, automerge, and schedule